### PR TITLE
feat(arc-runner): add Playwright browser dependencies

### DIFF
--- a/src/arc-runner/dockerfile
+++ b/src/arc-runner/dockerfile
@@ -8,6 +8,7 @@
 #   - yq: YAML processor
 #   - podman: Container engine
 #   - claude: Claude Code CLI
+#   - playwright-deps: Playwright/Chromium browser dependencies
 
 FROM ghcr.io/actions/actions-runner:latest
 
@@ -50,6 +51,11 @@ RUN apt-get update && \
 
 # Install claude (Claude Code CLI)
 RUN npm install -g @anthropic-ai/claude-code
+
+# Install playwright-deps (Playwright/Chromium browser dependencies)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libnspr4 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2 fonts-liberation xdg-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -54,3 +54,11 @@ tools:
     script: |
       npm install -g @anthropic-ai/claude-code
 
+  - name: playwright-deps
+    description: Playwright/Chromium browser dependencies
+    method: script
+    script: |
+      apt-get update
+      apt-get install -y --no-install-recommends libnspr4 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2 fonts-liberation xdg-utils
+      rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
## Summary
Add required system libraries for running Playwright/Chromium headless browser tests on the ARC runner.

## Dependencies Added
- libnspr4, libnss3 (NSS libraries)
- libatk1.0-0, libatk-bridge2.0-0, libatspi2.0-0 (Accessibility)
- libcups2 (Printing)
- libdrm2, libgbm1 (Graphics)
- libdbus-1-3 (D-Bus)
- libxcomposite1, libxdamage1, libxfixes3, libxrandr2, libxkbcommon0 (X11)
- libpango-1.0-0, libcairo2 (Text rendering)
- libasound2 (Audio)
- fonts-liberation, xdg-utils (Fonts and utilities)

## Why
This enables E2E tests with Playwright on self-hosted runners instead of GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)