### PR TITLE
feat(arc-runner): add build-essential

### DIFF
--- a/src/arc-runner/dockerfile
+++ b/src/arc-runner/dockerfile
@@ -2,6 +2,7 @@
 # AUTO-GENERATED from tools.yaml - do not edit directly!
 #
 # Tools included:
+#   - build-essential: C/C++ compiler and build tools
 #   - jq: JSON processor
 #   - gh: GitHub CLI
 #   - node: Node.js runtime
@@ -20,7 +21,7 @@ USER root
 
 # Install packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq && \
+    apt-get install -y --no-install-recommends build-essential jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor)

--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -6,6 +6,11 @@ multi_arch: false
 user: runner
 
 tools:
+  - name: build-essential
+    description: C/C++ compiler and build tools
+    method: package
+    package: build-essential
+
   - name: jq
     description: JSON processor
     method: package


### PR DESCRIPTION
## Summary
- Adds `build-essential` (gcc, g++, make) to the ARC runner image for compiling native dependencies in CI workflows

## Test plan
- [ ] CI builds the updated arc-runner image successfully
- [ ] Verify `gcc --version` and `make --version` work inside the runner container

🤖 Generated with [Claude Code](https://claude.com/claude-code)