### PR TITLE
feat(arc-runner): add Docker CLI and buildx plugin

### DIFF
--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -48,10 +48,21 @@ tools:
     script: |
       apt-get update
       apt-get install -y --no-install-recommends podman buildah skopeo fuse-overlayfs
-      ln -sf /usr/bin/podman /usr/local/bin/docker
       mkdir -p /etc/containers
       echo 'unqualified-search-registries = ["docker.io", "ghcr.io"]' > /etc/containers/registries.conf
       rm -rf /var/lib/apt/lists/*
+
+  - name: docker
+    description: Docker CLI and buildx plugin
+    method: script
+    script: |
+      curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | tar xz -C /tmp
+      mv /tmp/docker/docker /usr/local/bin/docker
+      rm -rf /tmp/docker
+      mkdir -p /usr/local/lib/docker/cli-plugins
+      curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-buildx \
+        https://github.com/docker/buildx/releases/download/v0.21.1/buildx-v0.21.1.linux-amd64
+      chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
   - name: claude
     description: Claude Code CLI


### PR DESCRIPTION
## Summary
- Install Docker CLI 27.5.1 and buildx plugin v0.21.1 into the ARC runner image
- Remove the `podman→docker` symlink since the real Docker CLI is now installed
- Podman/buildah/skopeo remain available alongside Docker

Part of the Docker buildx migration (replacing Kaniko). This provides the CLI — the daemon runs in a DinD sidecar added to the runner pod separately.

## Test plan
- [ ] Tag `1.2.0` and trigger image build
- [ ] Verify `docker --version` and `docker buildx version` work in the built image
- [ ] Verify `podman --version` still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)