### PR TITLE
feat(arc-runner): add python3-pip

### DIFF
--- a/src/arc-runner/dockerfile
+++ b/src/arc-runner/dockerfile
@@ -10,6 +10,7 @@
 #   - podman: Container engine
 #   - docker: Docker CLI and buildx plugin
 #   - claude: Claude Code CLI
+#   - python3-pip: Python package installer
 #   - playwright-deps: Playwright/Chromium browser dependencies
 
 FROM ghcr.io/actions/actions-runner:latest
@@ -22,7 +23,7 @@ USER root
 
 # Install packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential jq && \
+    apt-get install -y --no-install-recommends build-essential jq python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor)

--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -69,6 +69,11 @@ tools:
     script: |
       npm install -g @anthropic-ai/claude-code
 
+  - name: python3-pip
+    description: Python package installer
+    method: package
+    package: python3-pip
+
   - name: playwright-deps
     description: Playwright/Chromium browser dependencies
     method: script


### PR DESCRIPTION
## Summary
- Adds `python3-pip` package to the ARC runner image
- Enables workflow steps to `pip install playwright` for JS-heavy page rendering
- Chromium system deps were already added previously — this completes the Playwright story

## Context
Career-portal workflow scripts (`enhance-jobs.py`, `enrich-companies.py`) need Playwright to render pages that `urllib` can't handle. The runner already has the Chromium system libraries — this adds pip so workflows can install the Python playwright package.

## Test plan
- [ ] Image builds successfully
- [ ] `pip install playwright && playwright install chromium` works in a workflow step



Co-Authored-By: tomp736