### PR TITLE
feat(arc-runner): add node20_alpine externals for Alpine container support

### DIFF
--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -50,8 +50,9 @@ tools:
       NODE_VERSION="20.18.1"
       EXTERNALS_DIR="/home/runner/externals/node20_alpine"
       mkdir -p "$EXTERNALS_DIR"
-      curl -fsSL "https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.gz" \
-        | tar -xz -C "$EXTERNALS_DIR" --strip-components=1
+      curl -fsSL "https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.gz" -o /tmp/node-alpine.tar.gz
+      tar -xz -f /tmp/node-alpine.tar.gz -C "$EXTERNALS_DIR" --strip-components=1
+      rm /tmp/node-alpine.tar.gz
       chown -R runner:runner "$EXTERNALS_DIR"
 
   - name: yq

--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -36,6 +36,22 @@ tools:
       apt-get install -y --no-install-recommends nodejs
       rm -rf /var/lib/apt/lists/*
 
+  - name: node20-alpine-externals
+    description: |
+      Node 20 musl binary placed in the runner's externals directory so the
+      GitHub Actions runner can inject it into Alpine-based job containers
+      (used by `container:` workflow directives). Without this, JS actions
+      (e.g. actions/create-github-app-token) fail inside Alpine containers
+      with: stat /__e/node20_alpine/bin/node: no such file or directory.
+    method: script
+    script: |
+      NODE_VERSION="20.18.1"
+      EXTERNALS_DIR="/home/runner/externals/node20_alpine"
+      mkdir -p "$EXTERNALS_DIR"
+      curl -fsSL "https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.gz" \
+        | tar -xz -C "$EXTERNALS_DIR" --strip-components=1
+      chown -R runner:runner "$EXTERNALS_DIR"
+
   - name: yq
     description: YAML processor
     method: binary

--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -37,14 +37,16 @@ tools:
       rm -rf /var/lib/apt/lists/*
 
   - name: node20-alpine-externals
-    description: |
-      Node 20 musl binary placed in the runner's externals directory so the
-      GitHub Actions runner can inject it into Alpine-based job containers
-      (used by `container:` workflow directives). Without this, JS actions
-      (e.g. actions/create-github-app-token) fail inside Alpine containers
-      with: stat /__e/node20_alpine/bin/node: no such file or directory.
+    description: Node 20 musl in runner externals for Alpine job containers
     method: script
     script: |
+      # Without this, JS actions (e.g. actions/create-github-app-token) fail
+      # inside Alpine-based job containers (those set via the `container:`
+      # workflow directive) with:
+      #   stat /__e/node20_alpine/bin/node: no such file or directory
+      # The GH Actions runner mounts /home/runner/externals as /__e in the
+      # job container; we place the musl-linked node20 there so the runner
+      # can inject it when it detects Alpine via /etc/*release.
       NODE_VERSION="20.18.1"
       EXTERNALS_DIR="/home/runner/externals/node20_alpine"
       mkdir -p "$EXTERNALS_DIR"


### PR DESCRIPTION
## Summary

Adds Node 20 musl binary to the arc-runner image's externals so the GH Actions runner can inject it into Alpine-based job containers.

## Why

When a workflow uses `container:` with an Alpine-based image (e.g. `bor.infra.network` running inside `infra.images/omnibus`, which is based on `alpine-hardened`), the GH Actions runner detects Alpine via `cat /etc/*release` and tries to inject node from `/__e/node20_alpine/bin/node` to run any JS-based action. The path resolves to the runner's externals dir; without the alpine variant present, JS actions fail with:

```
OCI runtime exec failed: stat /__e/node20_alpine/bin/node: no such file or directory
```

## What this does

Downloads `node-v20.18.1-linux-x64-musl.tar.gz` from the [unofficial Node.js builds](https://unofficial-builds.nodejs.org/) (these are the musl-linked binaries used by Alpine) and extracts to `/home/runner/externals/node20_alpine/`. The runner mounts that path as `/__e/node20_alpine` inside the job container.

## Context

Surfaced during the `bor.infra.network` runner migration to `k8s-hetzner-arc` ([bor.infra.network#49](https://github.com/labrats-work/bor.infra.network/pull/49)). This is an org-wide fix — any future repo that uses `container:` with an Alpine image will work after this lands.

## Test plan

- [ ] Image builds successfully on `k8s-hetzner-arc`
- [ ] New image rolled into `labrats.work.hetzner.arc-runners` HelmRelease
- [ ] Re-run `bor.infra.network#49` deploy.yaml — JS action steps inside `omnibus` container succeed