### PR TITLE
feat(arc-runner): add terraform + wireguard-tools

### DIFF
--- a/src/arc-runner/tools.yaml
+++ b/src/arc-runner/tools.yaml
@@ -104,3 +104,21 @@ tools:
       apt-get install -y --no-install-recommends libnspr4 libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libdrm2 libdbus-1-3 libatspi2.0-0t64 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2t64 fonts-liberation xdg-utils
       rm -rf /var/lib/apt/lists/*
 
+  - name: terraform
+    description: Infrastructure as Code (used by IaC repos that exec terraform inside container directives)
+    method: script
+    script: |
+      TERRAFORM_VERSION="1.13.4"
+      curl -fsSL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+      unzip /tmp/terraform.zip -d /usr/local/bin
+      rm /tmp/terraform.zip
+      chmod +x /usr/local/bin/terraform
+
+  - name: wireguard-tools
+    description: WireGuard VPN tools (wg, wg-quick) for jobs that bring up tunnels via container directives
+    method: script
+    script: |
+      apt-get update
+      apt-get install -y --no-install-recommends wireguard-tools iptables unzip
+      rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
## Summary

Adds `terraform` (1.13.4) and `wireguard-tools` + `iptables` to the arc-runner image. This unblocks IaC workflows (like `bor.infra.network`'s deploy.yaml) that previously used the `omnibus` container — we're moving off Alpine and these tools need a home on the Debian-based arc-runner image.

## Context

[bor.infra.network](https://github.com/labrats-work/bor.infra.network) had been using `container: ghcr.io/labrats-work/infra.images/omnibus:main` for its terraform-plan and terraform-apply jobs (omnibus has both terraform and wireguard-tools). The recent decision to move off omnibus pointed `container.image` at a non-existent `labrats.work.hetzner.arc-runners:0.1.0` instead.

With `terraform` + `wireguard-tools` in arc-runner, the workflow can use `infra.images/arc-runner:<version>` as its job container — same image as the runner pod, fewer moving parts.

## Test plan

- [ ] arc-runner build passes CI
- [ ] After release tag + HelmRelease bump in `labrats.work.hetzner.arc-runners`, point `bor.infra.network` deploy.yaml at the new tag and confirm `wg-quick up` and `terraform plan` succeed inside the job container